### PR TITLE
Enhance exception and data provider tests

### DIFF
--- a/src/Tests/Encoding/ArrayEncoderTest.php
+++ b/src/Tests/Encoding/ArrayEncoderTest.php
@@ -15,11 +15,12 @@ use Opulence\Serialization\Encoding\ArrayEncoder;
 use Opulence\Serialization\Encoding\EncoderRegistry;
 use Opulence\Serialization\Encoding\EncodingContext;
 use Opulence\Serialization\Encoding\IEncoder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the array encoder
  */
-class ArrayEncoderTest extends \PHPUnit\Framework\TestCase
+class ArrayEncoderTest extends TestCase
 {
     /** @var EncoderRegistry The encoder registry */
     private $encoders;
@@ -51,12 +52,14 @@ class ArrayEncoderTest extends \PHPUnit\Framework\TestCase
     public function testDecodingNonArrayThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value must be an array');
         $this->arrayEncoder->decode('foo', 'string[]', new EncodingContext());
     }
 
     public function testDecodingTypeThatDoesNotEndInBracketsThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Type must end in "[]"');
         $this->arrayEncoder->decode(['foo'], 'bar', new EncodingContext());
     }
 
@@ -79,6 +82,7 @@ class ArrayEncoderTest extends \PHPUnit\Framework\TestCase
     public function testEncodingThrowInvalidArgumentExceptionWithNonArrayValues(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value must be an array');
         $this->arrayEncoder->encode(12345, new EncodingContext());
     }
 

--- a/src/Tests/Encoding/CamelCasePropertyNameFormatterTest.php
+++ b/src/Tests/Encoding/CamelCasePropertyNameFormatterTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Serialization\Tests\Encoding;
 
 use Opulence\Serialization\Encoding\CamelCasePropertyNameFormatter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the camel case property name formatter
  */
-class CamelCasePropertyNameFormatterTest extends \PHPUnit\Framework\TestCase
+class CamelCasePropertyNameFormatterTest extends TestCase
 {
     /** @var CamelCasePropertyNameFormatter The formatter to use in tests */
     private $formatter;
@@ -25,16 +26,24 @@ class CamelCasePropertyNameFormatterTest extends \PHPUnit\Framework\TestCase
         $this->formatter = new CamelCasePropertyNameFormatter();
     }
 
-    public function testPropertyNamesAreCamelCased(): void
+    public function propertyNamesAreCamelCasedProvider(): array
     {
-        $propertyNames = ['foo_bar', 'bar-baz', 'baz blah', 'blahDave'];
-        $expectedFormattedPropertyNames = ['fooBar', 'barBaz', 'bazBlah', 'blahDave'];
+        return [
+            ['foo_bar', 'fooBar'],
+            ['bar-baz', 'barBaz'],
+            ['baz blah', 'bazBlah'],
+            ['blahDave', 'blahDave'],
+        ];
+    }
 
-        for ($i = 0;$i < count($propertyNames);$i++) {
-            $this->assertEquals(
-                $expectedFormattedPropertyNames[$i],
-                $this->formatter->formatPropertyName($propertyNames[$i])
-            );
-        }
+    /**
+     * @dataProvider propertyNamesAreCamelCasedProvider
+     */
+    public function testPropertyNamesAreCamelCased($propertyName, $expectedFormattedPropertyName): void
+    {
+        $this->assertEquals(
+            $expectedFormattedPropertyName,
+            $this->formatter->formatPropertyName($propertyName)
+        );
     }
 }

--- a/src/Tests/Encoding/DateTimeEncoderTest.php
+++ b/src/Tests/Encoding/DateTimeEncoderTest.php
@@ -16,11 +16,12 @@ use DateTimeInterface;
 use InvalidArgumentException;
 use Opulence\Serialization\Encoding\DateTimeEncoder;
 use Opulence\Serialization\Encoding\EncodingContext;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the DateTime encoder
  */
-class DateTimeEncoderTest extends \PHPUnit\Framework\TestCase
+class DateTimeEncoderTest extends TestCase
 {
     /** @var DateTimeEncoder The encoder to test */
     private $dateTimeEncoder;
@@ -54,6 +55,7 @@ class DateTimeEncoderTest extends \PHPUnit\Framework\TestCase
     public function testDecodingNonDateTimeTypesThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Type must be DateTime, DateTimeImmutable, or DateTimeInterface');
         $this->dateTimeEncoder->decode(123, 'foo', new EncodingContext());
     }
 
@@ -69,6 +71,7 @@ class DateTimeEncoderTest extends \PHPUnit\Framework\TestCase
     public function testEncodingNonDateTimeThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value must implement DateTimeInterface');
         $this->dateTimeEncoder->encode('foo', new EncodingContext());
     }
 }

--- a/src/Tests/Encoding/EncodingContextTest.php
+++ b/src/Tests/Encoding/EncodingContextTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Serialization\Tests\Encoding;
 
 use Opulence\Serialization\Encoding\EncodingContext;
 use Opulence\Serialization\Tests\Encoding\Mocks\User;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the encoding context
  */
-class EncodingContextTest extends \PHPUnit\Framework\TestCase
+class EncodingContextTest extends TestCase
 {
     /** @var EncodingContext The context to test */
     private $context;

--- a/src/Tests/Encoding/ObjectEncoderTest.php
+++ b/src/Tests/Encoding/ObjectEncoderTest.php
@@ -33,11 +33,12 @@ use Opulence\Serialization\Tests\Encoding\Mocks\ConstructorWithUntypedVariadicPa
 use Opulence\Serialization\Tests\Encoding\Mocks\DerivedClassWithProperties;
 use Opulence\Serialization\Tests\Encoding\Mocks\NoConstructor;
 use Opulence\Serialization\Tests\Encoding\Mocks\User;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the object encoder
  */
-class ObjectEncoderTest extends \PHPUnit\Framework\TestCase
+class ObjectEncoderTest extends TestCase
 {
     /** @var EncoderRegistry The encoder registry */
     private $encoders;
@@ -53,6 +54,7 @@ class ObjectEncoderTest extends \PHPUnit\Framework\TestCase
     public function testDecodingClassWithArrayConstructorParamThrowsExceptionIfEncodedValueIsNotArray(): void
     {
         $this->expectException(EncodingException::class);
+        $this->expectExceptionMessage('Value must be an array');
         $this->objectEncoder->decode(['foo' => 'bar'], ConstructorWithArrayParams::class, new EncodingContext());
     }
 
@@ -199,6 +201,7 @@ class ObjectEncoderTest extends \PHPUnit\Framework\TestCase
     public function testDecodingClassWitVariadicConstructorParamThrowsExceptionIfEncodedValueIsNotArray(): void
     {
         $this->expectException(EncodingException::class);
+        $this->expectExceptionMessage('Value must be an array');
         $this->objectEncoder->decode(
             ['foo' => 'bar'],
             ConstructorWithUntypedVariadicParams::class,
@@ -238,18 +241,21 @@ class ObjectEncoderTest extends \PHPUnit\Framework\TestCase
     public function testDecodingHashMissingRequiredPropertyThrowsException(): void
     {
         $this->expectException(EncodingException::class);
+        $this->expectExceptionMessage('No value specified for parameter "user"');
         $this->objectEncoder->decode([], ConstructorWithTypedParams::class, new EncodingContext());
     }
 
     public function testDecodingNonArrayThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Type bar is not a valid class name');
         $this->objectEncoder->decode('foo', 'bar', new EncodingContext());
     }
 
     public function testEncodingCircularReferenceThrowsException(): void
     {
         $this->expectException(EncodingException::class);
+        $this->expectExceptionMessage('Circular reference detected');
         $a = new CircularReferenceA();
         $b = new CircularReferenceB($a);
         $a->setFoo($b);
@@ -344,18 +350,21 @@ class ObjectEncoderTest extends \PHPUnit\Framework\TestCase
     public function testEncodingNonObjectThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value must be an object');
         $this->objectEncoder->encode([], new EncodingContext());
     }
 
     public function testIgnoringPropertyNameThatIsNotStringOrArrayThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Property name must be a string or array of strings');
         $this->objectEncoder->addIgnoredProperty(User::class, $this);
     }
 
     public function testDecodingWithNonArrayObjectHashShouldThrowInvalidArgumentException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value must be an associative array');
         $this->objectEncoder->decode(12345, 'InvalidArgumentException', new EncodingContext());
     }
 }

--- a/src/Tests/Encoding/ScalarEncoderTest.php
+++ b/src/Tests/Encoding/ScalarEncoderTest.php
@@ -13,11 +13,12 @@ namespace Opulence\Serialization\Tests\Encoding;
 use InvalidArgumentException;
 use Opulence\Serialization\Encoding\EncodingContext;
 use Opulence\Serialization\Encoding\ScalarEncoder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the scalar encoder
  */
-class ScalarEncoderTest extends \PHPUnit\Framework\TestCase
+class ScalarEncoderTest extends TestCase
 {
     /** @var ScalarEncoder The encoder to use in tests */
     private $scalarEncoder;
@@ -30,6 +31,7 @@ class ScalarEncoderTest extends \PHPUnit\Framework\TestCase
     public function testDecodingNonScalarThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Type string[] is an invalid scalar');
         $this->scalarEncoder->decode(['foo'], 'string[]', new EncodingContext());
     }
 
@@ -46,6 +48,7 @@ class ScalarEncoderTest extends \PHPUnit\Framework\TestCase
     public function testEncodingNonScalarThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value must be scalar');
         $this->scalarEncoder->encode([], new EncodingContext());
     }
 

--- a/src/Tests/Encoding/SnakeCasePropertyNameFormatterTest.php
+++ b/src/Tests/Encoding/SnakeCasePropertyNameFormatterTest.php
@@ -11,11 +11,12 @@
 namespace Opulence\Serialization\Tests\Encoding;
 
 use Opulence\Serialization\Encoding\SnakeCasePropertyNameFormatter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the snake case property name formatter
  */
-class SnakeCasePropertyNameFormatterTest extends \PHPUnit\Framework\TestCase
+class SnakeCasePropertyNameFormatterTest extends TestCase
 {
     /** @var SnakeCasePropertyNameFormatter The formatter to use in tests */
     private $formatter;
@@ -25,16 +26,24 @@ class SnakeCasePropertyNameFormatterTest extends \PHPUnit\Framework\TestCase
         $this->formatter = new SnakeCasePropertyNameFormatter();
     }
 
-    public function testPropertyNamesAreSnakeCased(): void
+    public function propertyNamesAreSnakeCasedProvider(): array
     {
-        $propertyNames = ['foo_bar', 'bar-baz', 'baz blah', 'blahDave'];
-        $expectedFormattedPropertyNames = ['foo_bar', 'bar_baz', 'baz_blah', 'blah_dave'];
+        return [
+            ['foo_bar', 'foo_bar'],
+            ['bar-baz', 'bar_baz'],
+            ['baz blah', 'baz_blah'],
+            ['blahDave', 'blah_dave'],
+        ];
+    }
 
-        for ($i = 0;$i < count($propertyNames);$i++) {
-            $this->assertEquals(
-                $expectedFormattedPropertyNames[$i],
-                $this->formatter->formatPropertyName($propertyNames[$i])
-            );
-        }
+    /**
+     * @dataProvider propertyNamesAreSnakeCasedProvider
+     */
+    public function testPropertyNamesAreSnakeCased($propertyName, $expectedFormattedPropertyName): void
+    {
+        $this->assertEquals(
+            $expectedFormattedPropertyName,
+            $this->formatter->formatPropertyName($propertyName)
+        );
     }
 }

--- a/src/Tests/FormUrlEncodedSerializerTest.php
+++ b/src/Tests/FormUrlEncodedSerializerTest.php
@@ -16,11 +16,12 @@ use Opulence\Serialization\Encoding\IEncoder;
 use Opulence\Serialization\FormUrlEncodedSerializer;
 use Opulence\Serialization\SerializationException;
 use Opulence\Serialization\Tests\Encoding\Mocks\User;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the form URL-encoded serializer
  */
-class FormUrlEncodedSerializerTest extends \PHPUnit\Framework\TestCase
+class FormUrlEncodedSerializerTest extends TestCase
 {
     /** @var FormUrlEncodedSerializer The serializer to use in tests */
     private $serializer;
@@ -62,6 +63,7 @@ class FormUrlEncodedSerializerTest extends \PHPUnit\Framework\TestCase
     public function testEncodingExceptionThrownDuringDeserializationIsRethrown(): void
     {
         $this->expectException(SerializationException::class);
+        $this->expectExceptionMessage('Failed to deserialize value');
         $encoder = $this->createMock(IEncoder::class);
         $encoder->expects($this->once())
             ->method('decode')
@@ -74,6 +76,7 @@ class FormUrlEncodedSerializerTest extends \PHPUnit\Framework\TestCase
     public function testEncodingExceptionThrownDuringSerializationIsRethrown(): void
     {
         $this->expectException(SerializationException::class);
+        $this->expectExceptionMessage('Failed to serialize value');
         $user = new User(123, 'foo@bar.com');
         $encoder = $this->createMock(IEncoder::class);
         $encoder->expects($this->once())

--- a/src/Tests/JsonSerializerTest.php
+++ b/src/Tests/JsonSerializerTest.php
@@ -16,11 +16,12 @@ use Opulence\Serialization\Encoding\IEncoder;
 use Opulence\Serialization\JsonSerializer;
 use Opulence\Serialization\SerializationException;
 use Opulence\Serialization\Tests\Encoding\Mocks\User;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the JSON serializer
  */
-class JsonSerializerTest extends \PHPUnit\Framework\TestCase
+class JsonSerializerTest extends TestCase
 {
     /** @var JsonSerializer The serializer to use in tests */
     private $serializer;
@@ -62,12 +63,14 @@ class JsonSerializerTest extends \PHPUnit\Framework\TestCase
     public function testDeserializingInvalidJsonThrowsException(): void
     {
         $this->expectException(SerializationException::class);
+        $this->expectExceptionMessage('Failed to deserialize value');
         $this->serializer->deserialize('"', self::class);
     }
 
     public function testEncodingExceptionThrownDuringDeserializationIsRethrown(): void
     {
         $this->expectException(SerializationException::class);
+        $this->expectExceptionMessage('Failed to deserialize value');
         $encoder = $this->createMock(IEncoder::class);
         $encoder->expects($this->once())
             ->method('decode')
@@ -80,6 +83,7 @@ class JsonSerializerTest extends \PHPUnit\Framework\TestCase
     public function testEncodingExceptionThrownDuringSerializationIsRethrown(): void
     {
         $this->expectException(SerializationException::class);
+        $this->expectExceptionMessage('Failed to serialize value');
         $user = new User(123, 'foo@bar.com');
         $encoder = $this->createMock(IEncoder::class);
         $encoder->expects($this->once())
@@ -93,6 +97,7 @@ class JsonSerializerTest extends \PHPUnit\Framework\TestCase
     public function testSerializeThrowSerializationExceptionDuringJsonEncoding(): void
     {
         $this->expectException(SerializationException::class);
+        $this->expectExceptionMessage('Failed to serialize value');
         $this->serializer->serialize(123456);
     }
 }

--- a/src/Tests/TypeResolverTest.php
+++ b/src/Tests/TypeResolverTest.php
@@ -12,11 +12,12 @@ namespace Opulence\Serialization\Tests;
 
 use Opulence\Serialization\Tests\Encoding\Mocks\User;
 use Opulence\Serialization\TypeResolver;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the type resolver
  */
-class TypeResolverTest extends \PHPUnit\Framework\TestCase
+class TypeResolverTest extends TestCase
 {
     public function testGettingArrayTypeReturnsNullForNonTypedArrays(): void
     {
@@ -27,7 +28,7 @@ class TypeResolverTest extends \PHPUnit\Framework\TestCase
 
     public function testGettingArrayTypeReturnsTypeTypedArrays(): void
     {
-        $this->assertEquals(User::class, TypeResolver::getArrayType(User::class . '[]'));
+        $this->assertSame(User::class, TypeResolver::getArrayType(User::class . '[]'));
     }
 
     public function testResolvingEmptyArrayReturnsArrayType(): void
@@ -42,7 +43,7 @@ class TypeResolverTest extends \PHPUnit\Framework\TestCase
 
     public function testResolvingTypeForObjectUsesObjectsClassName(): void
     {
-        $this->assertEquals(User::class, TypeResolver::resolveType(new User(123, 'foo@bar.com')));
+        $this->assertSame(User::class, TypeResolver::resolveType(new User(123, 'foo@bar.com')));
     }
 
     public function testResolvingTypeForScalarUsesScalarType(): void


### PR DESCRIPTION
# Changed log
- Using `use` namespace syntax to be consistent.
- Using `dataProvider` approach to collect tests cases.
- Add the `expectExceptionMessage` method to assert the expected exception message is same as exception message result.